### PR TITLE
Change gutter styles to match default sublime text theme

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -7,10 +7,10 @@
 @orange: #fe8827;
 
 // GUTTER
-@gutter-text: rgb(64,75,83);
-@gutter-text-highlight: @entity;
-@gutter-background: rgb(14,17,18);
-@gutter-background-highlight: rgb(6,7,8);
+@gutter-text: #8f908a;
+@gutter-text-highlight: #8f908a;
+@gutter-background: #272822;
+@gutter-background-highlight: #3e3d32;
 
 // CODE VIEW
 @code-background: #272822; // editor background


### PR DESCRIPTION
This change addresses #5. It changes the gutter styles to match those of the default sublime text theme.